### PR TITLE
Bump jinja2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ gitdb2==2.0.5
 GitPython==2.1.11
 idna==2.8
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.10.1
 jmespath==0.9.4
 MarkupSafe==1.1.1
 pycodestyle==2.5.0


### PR DESCRIPTION
2.10.0 has a vulnerability, although the function in question is not used in this project. Always good to upgrade anyway.

Consider setting up dependabot to keep these up to date.